### PR TITLE
Use proper code for locale

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 			}
 		},
 		"flarum-locale": {
-			"code": "sr_Cyrl",
+			"code": "sr-Cyrl",
 			"title": "Serbian (Cyrillic)"
 		},
 		"extiverse": {


### PR DESCRIPTION
This PR replaces code with a valid [BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag). 

The existing code prevented the creation of `Intl.PluralRules()` object, which resulted in JavaScript errors rendering this language pack unusable. 